### PR TITLE
Correct setting.find_or_default to do what it says

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -261,7 +261,10 @@ class Setting < ActiveRecord::Base
       setting = new(:name => name)
       setting.value = @@available_settings[name]['default']
     end
-    setting ||= find_by_name(name)
+    if find_by_name(name)
+      setting = find_by_name(name)
+    end
+
   end
 
 end


### PR DESCRIPTION
The previous "setting ||= find_by_name(name)" line failed to load settings (only overwrote the setting if it did not contain a default - a condition guaranteed by the previous conditional to never occur)

"||=" is "set value if not already set" not "set value if right side isn't nil". There's probably a more graceful way to do this that doesn't involve pulling the setting -twice-, but I'm brand new to Ruby and have no idea how to do that. :)
